### PR TITLE
Enable footnotes extension

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,6 +120,7 @@ func main() {
 	extensions |= blackfriday.EXTENSION_AUTOLINK
 	extensions |= blackfriday.EXTENSION_STRIKETHROUGH
 	extensions |= blackfriday.EXTENSION_SPACE_HEADERS
+	extensions |= blackfriday.EXTENSION_FOOTNOTES
 
 	var renderer blackfriday.Renderer
 	if latex {


### PR DESCRIPTION
The footnotes extension `blackfriday.EXTENSION_FOOTNOTES` is not included yet.
Since it is mentioned in the documentation among the other already included extensions, it would be nice to have it activated as well.